### PR TITLE
Changed depricated experimental_get_query_params method with query_pa…

### DIFF
--- a/components/authenticate.py
+++ b/components/authenticate.py
@@ -43,9 +43,9 @@ def get_auth_code():
     Returns:
         Nothing.
     """
-    auth_query_params = st.experimental_get_query_params()
     try:
-        auth_code = dict(auth_query_params)["code"][0]
+        auth_query_params = st.query_params.to_dict()
+        auth_code = auth_query_params.get("code", "")
     except (KeyError, TypeError):
         auth_code = ""
 


### PR DESCRIPTION
## Changes made
- changed the experimental_get_query_params cause it was depricated from streamlit version 1.30.0. and will not work in April. 

### Links
https://docs.streamlit.io/library/api-reference/utilities/st.experimental_get_query_params